### PR TITLE
uigen: reject assignment to readonly property

### DIFF
--- a/lib/src/typemap/class.rs
+++ b/lib/src/typemap/class.rs
@@ -215,6 +215,11 @@ impl<'a> Property<'a> {
         &self.data.as_ref().type_name
     }
 
+    /// Whether or not this property can be set.
+    pub fn is_writable(&self) -> bool {
+        self.data.as_ref().write_func_name.is_some()
+    }
+
     /// Whether or not this property provides the standard setter function.
     ///
     /// See `PropertyDef::stdCppSet()` in `qtbase/src/tools/moc/moc.h` for details.

--- a/lib/src/uigen/layout.rs
+++ b/lib/src/uigen/layout.rs
@@ -74,10 +74,11 @@ impl Layout {
         class: &Class,
         name: Option<String>,
         attributes: LayoutAttributes,
-        properties_map: PropertiesMap,
+        mut properties_map: PropertiesMap,
         children: Vec<LayoutItem>,
         diagnostics: &mut Diagnostics,
     ) -> Self {
+        property::reject_unwritable_properties(&mut properties_map, diagnostics);
         let mut properties = property::make_serializable_properties(properties_map, diagnostics);
         // TODO: if metatypes were broken, contentsMargins could be of different type
         if let Some((Value::Gadget(m), s)) = properties.remove("contentsMargins") {
@@ -337,6 +338,7 @@ impl SpacerItem {
         properties_map: PropertiesMap,
         diagnostics: &mut Diagnostics,
     ) -> Self {
+        // no check for writable as all spacer properties are translated by uic
         let properties = property::make_serializable_properties(properties_map, diagnostics);
         SpacerItem { name, properties }
     }

--- a/lib/src/uigen/object.rs
+++ b/lib/src/uigen/object.rs
@@ -95,9 +95,10 @@ pub struct Action {
 impl Action {
     pub(super) fn new(
         name: Option<String>,
-        properties_map: PropertiesMap,
+        mut properties_map: PropertiesMap,
         diagnostics: &mut Diagnostics,
     ) -> Self {
+        property::reject_unwritable_properties(&mut properties_map, diagnostics);
         let properties = property::make_serializable_properties(properties_map, diagnostics);
         Action { name, properties }
     }
@@ -249,6 +250,8 @@ impl Widget {
                 diagnostics,
             );
         }
+
+        property::reject_unwritable_properties(&mut properties_map, diagnostics);
         let mut properties = property::make_serializable_properties(properties_map, diagnostics);
         if class.is_derived_from(&ctx.classes.push_button) {
             // see metatype_tweak.rs, "default" is a reserved word

--- a/lib/src/uigen/property.rs
+++ b/lib/src/uigen/property.rs
@@ -237,6 +237,26 @@ where
         .collect()
 }
 
+/// Makes sure all properties are writable, removes if not.
+///
+/// This should be called at the very last but before `make_serializable_properties()`
+/// where all pseudo properties would have been transformed.
+pub(super) fn reject_unwritable_properties(
+    properties_map: &mut PropertiesMap,
+    diagnostics: &mut Diagnostics,
+) {
+    properties_map.retain(|_, v| {
+        let writable = v.data().desc.is_writable();
+        if !writable {
+            diagnostics.push(Diagnostic::error(
+                v.binding_node().byte_range(),
+                "not a writable property",
+            ));
+        }
+        writable
+    });
+}
+
 pub(super) fn make_gadget_properties(
     properties_map: PropertiesMap,
     diagnostics: &mut Diagnostics,

--- a/tests/test_uigen_item_model.rs
+++ b/tests/test_uigen_item_model.rs
@@ -59,5 +59,5 @@ fn test_string_list_as_list_view_item() {
     insta::assert_snapshot!(common::translate_str(r###"
     import qmluic.QtWidgets
     QListView { model: ["foo"] }
-    "###).unwrap_err(), @"<unknown>:2:20: error: unexpected type of value");
+    "###).unwrap_err(), @"<unknown>:2:13: error: not a writable property");
 }

--- a/tests/test_uigen_widget.rs
+++ b/tests/test_uigen_widget.rs
@@ -15,3 +15,11 @@ fn test_reserved_word_workaround() {
     </ui>
     "###);
 }
+
+#[test]
+fn test_width_is_readonly() {
+    insta::assert_snapshot!(common::translate_str(r###"
+    import qmluic.QtWidgets
+    QWidget { width: 100 }
+    "###).unwrap_err(), @"<unknown>:2:11: error: not a writable property");
+}


### PR DESCRIPTION
This should detect common mistakes to set width/height properties.