### PR TITLE
push 8c80dbe980e84f38974151d6ef773129

### DIFF
--- a/lib/src/qmlast/expr.rs
+++ b/lib/src/qmlast/expr.rs
@@ -1,4 +1,5 @@
 use super::astutil::{self, Number};
+use super::node::StatementNode;
 use super::term::{self, Identifier, NestedIdentifier};
 use super::{ParseError, ParseErrorKind};
 use std::fmt;
@@ -210,7 +211,7 @@ impl<'tree> Function<'tree> {
                     name,
                     parameters,
                     return_ty,
-                    body: FunctionBody::Statement(body_node),
+                    body: FunctionBody::Statement(StatementNode(body_node)),
                 })
             }
             "arrow_function" => {
@@ -239,7 +240,7 @@ impl<'tree> Function<'tree> {
                     .transpose()?;
                 let body_node = astutil::get_child_by_field_name(node, "body")?;
                 let body = if body_node.kind() == "statement_block" {
-                    FunctionBody::Statement(body_node)
+                    FunctionBody::Statement(StatementNode(body_node))
                 } else {
                     FunctionBody::Expression(body_node)
                 };
@@ -261,7 +262,7 @@ impl<'tree> Function<'tree> {
 #[derive(Clone, Copy, Debug)]
 pub enum FunctionBody<'tree> {
     Expression(Node<'tree>),
-    Statement(Node<'tree>),
+    Statement(StatementNode<'tree>),
 }
 
 /// Represents a function parameter.

--- a/lib/src/qmlast/mod.rs
+++ b/lib/src/qmlast/mod.rs
@@ -6,11 +6,13 @@ use std::ops::Range;
 
 mod astutil;
 mod expr;
+mod node;
 mod object;
 mod stmt;
 mod term;
 
 pub use self::expr::*; // re-export
+pub use self::node::*; // re-export
 pub use self::object::*; // re-export
 pub use self::stmt::*; // re-export
 pub use self::term::*; // re-export

--- a/lib/src/qmlast/node.rs
+++ b/lib/src/qmlast/node.rs
@@ -1,0 +1,28 @@
+//! Newtype for Node.
+
+use super::stmt::Statement;
+use super::ParseError;
+use std::ops::Range;
+use tree_sitter::{Node, TreeCursor};
+
+/// CST node that represents a [`Statement`](Statement).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct StatementNode<'tree>(pub(super) Node<'tree>);
+
+impl<'tree> StatementNode<'tree> {
+    pub fn parse(&self) -> Result<Statement<'tree>, ParseError<'tree>> {
+        Statement::from_node(*self)
+    }
+
+    pub(super) fn inner_node(&self) -> Node<'tree> {
+        self.0
+    }
+
+    pub fn byte_range(&self) -> Range<usize> {
+        self.0.byte_range()
+    }
+
+    pub(super) fn walk(&self) -> TreeCursor<'tree> {
+        self.0.walk()
+    }
+}

--- a/lib/src/qmlast/object.rs
+++ b/lib/src/qmlast/object.rs
@@ -1,5 +1,6 @@
 use super::astutil;
 use super::node::StatementNode;
+use super::stmt::Statement;
 use super::term::{Identifier, NestedIdentifier};
 use super::{ParseError, ParseErrorKind};
 use std::collections::HashMap;
@@ -141,14 +142,14 @@ impl<'tree> UiImport<'tree> {
 }
 
 fn extract_object_id(node: StatementNode) -> Result<Identifier, ParseError> {
-    // (expression_statement (identifier))
-    let mut node = node.inner_node(); // TODO: maybe use node.parse()?
-    if node.kind() == "expression_statement" {
-        node = node
-            .child(0)
-            .ok_or_else(|| ParseError::new(node, ParseErrorKind::InvalidSyntax))?;
+    if let Statement::Expression(n) = node.parse()? {
+        Identifier::from_node(n)
+    } else {
+        Err(ParseError::new(
+            node.inner_node(),
+            ParseErrorKind::UnexpectedNodeKind,
+        ))
     }
-    Identifier::from_node(node)
 }
 
 /// Represents a QML object or top-level component.

--- a/lib/src/tir/builder.rs
+++ b/lib/src/tir/builder.rs
@@ -5,7 +5,7 @@ use super::core::{
 };
 use crate::diagnostic::Diagnostics;
 use crate::opcode::{BinaryArithOp, BinaryOp, BuiltinFunctionKind, UnaryOp};
-use crate::qmlast::Node;
+use crate::qmlast::StatementNode;
 use crate::typedexpr::{
     self, DescribeType, ExpressionError, ExpressionVisitor, RefSpace, TypeAnnotationSpace, TypeDesc,
 };
@@ -736,7 +736,7 @@ fn check_object_subscript_type<'a>(
 /// Translates expression AST nodes into type-checked IR.
 pub fn build<'a, C>(
     ctx: &C,
-    node: Node,
+    node: StatementNode,
     source: &str,
     diagnostics: &mut Diagnostics,
 ) -> Option<CodeBody<'a>>
@@ -758,7 +758,7 @@ where
 /// parameters will be built. Otherwise this function is identical to `build()`.
 pub fn build_callback<'a, C>(
     ctx: &C,
-    node: Node,
+    node: StatementNode,
     source: &str,
     diagnostics: &mut Diagnostics,
 ) -> Option<CodeBody<'a>>

--- a/lib/src/tir/builder.rs
+++ b/lib/src/tir/builder.rs
@@ -469,11 +469,6 @@ impl<'a> ExpressionVisitor<'a> for CodeBuilder<'a> {
         (alternative, alternative_ref): (Self::Item, Self::Label),
         byte_range: Range<usize>,
     ) -> Result<Self::Item, ExpressionError<'a>> {
-        if condition.type_desc() != TypeDesc::BOOL {
-            return Err(ExpressionError::IncompatibleConditionType(
-                condition.type_desc(),
-            ));
-        }
         let consequence = ensure_concrete_string(consequence);
         let alternative = ensure_concrete_string(alternative);
         let ty = deduce_concrete_type("ternary", consequence.type_desc(), alternative.type_desc())?;
@@ -508,11 +503,6 @@ impl<'a> ExpressionVisitor<'a> for CodeBuilder<'a> {
         consequence_ref: Self::Label,
         alternative_ref: Option<Self::Label>,
     ) -> Result<(), ExpressionError<'a>> {
-        if condition.type_desc() != TypeDesc::BOOL {
-            return Err(ExpressionError::IncompatibleConditionType(
-                condition.type_desc(),
-            ));
-        }
         self.get_basic_block_mut(condition_ref)
             .finalize(Terminator::BrCond(
                 condition,

--- a/lib/tests/tir_testenv/mod.rs
+++ b/lib/tests/tir_testenv/mod.rs
@@ -3,7 +3,7 @@
 use qmluic::diagnostic::Diagnostics;
 use qmluic::metatype;
 use qmluic::opcode::BuiltinFunctionKind;
-use qmluic::qmlast::{Node, UiObjectDefinition, UiProgram};
+use qmluic::qmlast::{StatementNode, UiObjectDefinition, UiProgram};
 use qmluic::qmldoc::UiDocument;
 use qmluic::tir::{self, CodeBody};
 use qmluic::typedexpr::{RefKind, RefSpace, TypeAnnotationSpace};
@@ -120,7 +120,7 @@ impl Env {
     fn try_build_with<'a>(
         &'a self,
         expr_source: &str,
-        build: impl FnOnce(&Context<'a>, Node, &str, &mut Diagnostics) -> Option<CodeBody<'a>>,
+        build: impl FnOnce(&Context<'a>, StatementNode, &str, &mut Diagnostics) -> Option<CodeBody<'a>>,
     ) -> Result<CodeBody<'a>, Diagnostics> {
         let mut type_space = ImportedModuleSpace::new(&self.type_map);
         assert!(type_space.import_module(ModuleId::Builtins));

--- a/tests/test_uigen_widget.rs
+++ b/tests/test_uigen_widget.rs
@@ -480,7 +480,7 @@ fn test_ternary_condition_string() {
       ┌─ <unknown>:3:11
       │
     3 │     text: windowTitle ? windowTitle : "untitled"
-      │           ----------- type: QString
+      │           ^^^^^^^^^^^ type: QString
       │
       = use (!expr.isEmpty()) to test empty string
     "###);
@@ -500,7 +500,7 @@ fn test_if_condition_int() {
       ┌─ <unknown>:4:12
       │
     4 │         if (value) {}
-      │            ------- type: int
+      │            ^^^^^^^ type: int
       │
       = use (expr != 0) to test zero
     "###);
@@ -520,7 +520,7 @@ fn test_if_condition_flag() {
       ┌─ <unknown>:4:12
       │
     4 │         if (alignment & Qt.AlignLeft) {}
-      │            -------------------------- type: Qt::Alignment
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^ type: Qt::Alignment
       │
       = use ((expr as int) != 0) to test flag
     "###);


### PR DESCRIPTION
- typedexpr: move condition type checking from tir builder
- typedexpr: remove useless result from visit_*_statement()
- qmlast: wrap value node with UiBindingNotation enum
- qmlast: introduce newtype for statement node
- qmlast: use statement parser to extract object id
