### PR TITLE
github: run clippy at minimum supported Rust version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install clippy
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.61"
           profile: minimal
           components: clippy
           override: true


### PR DESCRIPTION
Apparently, the stable clippy starts suggesting then_some(), which isn't available at Rust 1.61.